### PR TITLE
Aligned publish with main in github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,18 +9,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: ['16.x', '18.x', '20.x']
+        node: ['22.x', '24.x']
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           registry-url: https://registry.npmjs.org/
+          cache: 'npm'
 
       - name: Install deps and build (with cache)
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION
# Release Notes

## Version 1.1.0

### Build Tool Migration
- Replaced `tsdx` with `tsup` for improved build performance and simpler configuration
- Removed `tslib` dependency (bundled by tsup)

### Test Framework Migration
- Migrated from Jest to Vitest
- Updated mock syntax: `jest.fn()` → `vi.fn()` from vitest
- Added `jsdom` as a dev dependency for Vitest's DOM testing support

### Node.js Requirements
- Minimum Node.js version increased from `14.x` to `22.x`

### Package Configuration Updates
- Added `"type": "module"` for ESM support
- Updated exports field with dual ESM/CJS exports:
  - ESM: `dist/index.js` with `dist/index.d.ts` types
  - CJS: `dist/index.cjs` with `dist/index.d.cts` types
- Removed `src` from published files (only `dist` is published)

### Removed Dependencies
- `husky` and pre-commit hooks
- `@size-limit/webpack` and `@size-limit/webpack-why`

### Updated Dependencies
- `@size-limit/preset-small-lib`: 7.0.5 → 12.0.1
- `size-limit`: 7.0.5 → 12.0.1
- `typescript`: 4.5.4 → 5.5.4

### Type Improvements
- Changed `Object` to `object` in global XMLCclRequest type declarations (lowercase primitive type is more correct)

### GitHub Actions
- Updated publish workflow to use Node.js 22
- Aligned main and publish workflows

### CLI Scripts
- Removed: `start`, `test:watchall`, `analyze`, `demo`
- Simplified: `test` now uses `vitest run`