### PR TITLE
Bump Node.js version to 24 in CI/CD pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,19 +47,16 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Use Node 22.x
+      - name: Use Node 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '24.x'
 
       - name: Install deps
         uses: bahmutov/npm-install@v1
 
       - name: Build package
         run: npm run build
-
-      - name: Upgrade npm
-        run: npm install -g npm@latest
 
       - name: Publish to npm
         run: npm publish --provenance --access public


### PR DESCRIPTION
This pull request updates the Node.js version used in the GitHub Actions workflow for publishing, and removes a step that upgraded npm. These changes help keep our CI environment up-to-date and simplify the workflow.

**Workflow environment updates:**

* Updated the Node.js version in `.github/workflows/publish.yml` from `22.x` to `24.x` to ensure compatibility with the latest Node.js features and security updates.
* Removed the explicit npm upgrade step, relying on the default npm version bundled with Node.js 24.x, which simplifies maintenance.